### PR TITLE
Fix data inclusion bug

### DIFF
--- a/kegg_pathways_completeness/bin/give_pathways.py
+++ b/kegg_pathways_completeness/bin/give_pathways.py
@@ -307,6 +307,7 @@ def get_weights_for_KOs(graphs):
     return dict_graphKO
 
 def main():
+
     default_graphs_path = files('kegg_pathways_completeness.graphs').joinpath('graphs.pkl')
     default_pathways_path = files('kegg_pathways_completeness.pathways_data').joinpath('all_pathways.txt')
     default_pathways_names_path = files('kegg_pathways_completeness.pathways_data').joinpath('all_pathways_names.txt')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kegg-pathways-completeness"
-version = "1.0.2"
+version = "1.0.3"
 readme = "README.md"
 license = {text = "Apache Software License 2.0"}
 authors = [
@@ -35,6 +35,9 @@ packages = [
     "kegg_pathways_completeness.graphs",
     "kegg_pathways_completeness.pathways_data"
 ]
+
+[tool.setuptools.package-data]
+"*" = ["graphs.pkl", "*.txt"]
 
 [project.scripts]
 give_pathways = "kegg_pathways_completeness.bin.give_pathways:main"


### PR DESCRIPTION
Tried using the container for the recently published bioconda tool, however `give_pathways.py` doesn't work because it can't find the graphs pickle file or the pathway .txt files.

I had to add something to the pyproject.toml file, and declare default values for the arguments for those files in the `give_pathways.py`. The way it's done is the setuptools recommended way using `importlib.resources.files` described here: https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime

